### PR TITLE
Paperclip compatibility

### DIFF
--- a/lib/mod_porter.rb
+++ b/lib/mod_porter.rb
@@ -16,6 +16,10 @@ module ModPorter
       @content_type = options[:content_type]
     end
 
+    def read
+      File.read(self.path)
+    end
+
     def to_tempfile
       return File.new(self.path)
     end


### PR DESCRIPTION
Some versions of Paperclip expect a #read method for UploadedFile. This commit just uses File#read to handle that.
